### PR TITLE
解决remoting层  报超时的问题

### DIFF
--- a/rocketmq-remoting/src/main/java/com/alibaba/rocketmq/remoting/netty/NettyRemotingAbstract.java
+++ b/rocketmq-remoting/src/main/java/com/alibaba/rocketmq/remoting/netty/NettyRemotingAbstract.java
@@ -247,8 +247,8 @@ public abstract class NettyRemotingAbstract {
         final ResponseFuture responseFuture = responseTable.get(cmd.getOpaque());
         if (responseFuture != null) {
             responseFuture.setResponseCommand(cmd);
-
             responseFuture.release();
+            responseTable.remove(cmd.getOpaque());
 
             if (responseFuture.getInvokeCallback() != null) {
                 boolean runInThisThread = false;
@@ -295,7 +295,6 @@ public abstract class NettyRemotingAbstract {
             plog.warn(cmd.toString());
         }
 
-        responseTable.remove(cmd.getOpaque());
     }
 
 


### PR DESCRIPTION
场景：
1、构造一个request的RemotingCommand。
2、然后用这个对象作为参数  循环往多台机器上发送这个请求。
3、伪代码形如：
RemotingCommand request =
                RemotingCommand.createRequestCommand(RequestCode.REGISTER_BROKER, requestHeader);
for(...){
	remotingClient.invokeSync("address:port",request,30000)
}

现象：
调用端应用的日志中随机性地出现[addr:port] Exception, wait response on the channel <10.214.104.42:9505> timeout, 3000(ms)的异常。

问题原因和分析：
比如发起了2次调用，第一次调用发起后，remoting层会调用countDownLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)方法让发起调用线程一直卡住等待服务端返回结果，当结果返回时会调用NettyRemotingAbstract类的processResponseCommand方法，这个方法会先调用countDownLatch.countDown()唤醒之前的调用线程，同时会把responseTable中的responseFuture值给删除。
而因为第二次请求和第一次请求用的是同一个requestCommand对象，而刚好第二次调用在等待服务端返回时，第一次的请求把responseTable的值给删除了，导致当第二次调用服务端返回时就找不到responseFuture值。那么调用线程就会由于一直没被countDownLatch.countDown方法调用一直卡着，直到超时抛异常返回。

解决方法：
在唤醒调用线程前把这次的responseFuture给删除，保证下一次调用的开始前不会有其他的程序在操作responseTable对象中 同一个opaque作为key的responseFuture对象。