### PR TITLE
依赖于netty5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <inceptionYear>2012</inceptionYear>
     <groupId>com.alibaba.rocketmq</groupId>
     <artifactId>rocketmq-all</artifactId>
-    <version>3.2.6</version>
+    <version>3.2.7</version>
     <packaging>pom</packaging>
     <name>rocketmq-all ${project.version}</name>
     <url>https://github.com/alibaba/rocketmq</url>
@@ -186,7 +186,7 @@
                 </configuration>
             </plugin>
 
-
+<!--
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.5.3</version>
@@ -197,8 +197,8 @@
                     </descriptors>
                 </configuration>
             </plugin>
-
-            <!--
+-->
+            
                         <plugin>
                             <artifactId>maven-assembly-plugin</artifactId>
                             <configuration>
@@ -208,7 +208,7 @@
                                 </descriptors>
                             </configuration>
                         </plugin>
-            -->
+            
 
 
             <plugin>
@@ -381,7 +381,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.0.25.Final</version>
+                <version>5.0.0.Alpha2</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba</groupId>

--- a/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/pagecache/ManyMessageTransfer.java
+++ b/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/pagecache/ManyMessageTransfer.java
@@ -94,4 +94,30 @@ public class ManyMessageTransfer extends AbstractReferenceCounted implements Fil
     public long transfered() {
         return transfered;
     }
+
+
+	@Override
+	public FileRegion retain() {
+		super.retain();
+		return this;
+	}
+
+
+	@Override
+	public FileRegion retain(int i) {
+		super.retain(i);
+		return this;
+	}
+
+
+	@Override
+	public FileRegion touch() {
+		return this;
+	}
+
+
+	@Override
+	public FileRegion touch(Object obj) {
+		return this;
+	}
 }

--- a/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/pagecache/OneMessageTransfer.java
+++ b/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/pagecache/OneMessageTransfer.java
@@ -83,4 +83,30 @@ public class OneMessageTransfer extends AbstractReferenceCounted implements File
     public long transfered() {
         return transfered;
     }
+
+
+	@Override
+	public FileRegion retain() {
+		super.retain();
+		return this;
+	}
+
+
+	@Override
+	public FileRegion retain(int i) {
+		super.retain(i);
+		return this;
+	}
+
+
+	@Override
+	public FileRegion touch() {
+		return this;
+	}
+
+
+	@Override
+	public FileRegion touch(Object obj) {
+		return this;
+	}
 }

--- a/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/pagecache/QueryMessageTransfer.java
+++ b/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/pagecache/QueryMessageTransfer.java
@@ -94,4 +94,30 @@ public class QueryMessageTransfer extends AbstractReferenceCounted implements Fi
     public long transfered() {
         return transfered;
     }
+
+
+	@Override
+	public FileRegion retain() {
+		super.retain();
+		return this;
+	}
+
+
+	@Override
+	public FileRegion retain(int i) {
+		super.retain(i);
+		return this;
+	}
+
+
+	@Override
+	public FileRegion touch() {
+		return this;
+	}
+
+
+	@Override
+	public FileRegion touch(Object obj) {
+		return this;
+	}
 }

--- a/rocketmq-client/src/main/java/com/alibaba/rocketmq/client/producer/DefaultMQProducer.java
+++ b/rocketmq-client/src/main/java/com/alibaba/rocketmq/client/producer/DefaultMQProducer.java
@@ -140,7 +140,7 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     @Override
     public void send(Message msg, MessageQueue mq, SendCallback sendCallback) throws MQClientException,
             RemotingException, InterruptedException {
-        send(msg, mq, sendCallback);
+    	this.defaultMQProducerImpl.send(msg, mq, sendCallback);
     }
 
 


### PR DESCRIPTION
升级netty依赖到netty5
1：因为业务使用了netty5与rocketMQ的netty4冲突，所以升级rocketMQ依赖到netty5。
2：bugfix: rocketmq-client-3.2.6 生产者发送消息递归死循环问题(https://github.com/alibaba/RocketMQ/issues/140)