### PR TITLE
Fix config file issues.

### DIFF
--- a/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -27,7 +27,6 @@ import com.alibaba.rocketmq.remoting.protocol.RemotingSerializable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -152,8 +151,7 @@ public class SubscriptionGroupManager extends ConfigManager {
 
     @Override
     public String configFilePath() {
-        //return BrokerPathConfigHelper.getSubscriptionGroupPath(this.brokerController.getMessageStoreConfig().getStorePathRootDir());
-        return BrokerPathConfigHelper.getSubscriptionGroupPath(System.getProperty("user.home") + File.separator + "store");
+        return BrokerPathConfigHelper.getSubscriptionGroupPath(this.brokerController.getMessageStoreConfig().getStorePathRootDir());
     }
 
     @Override

--- a/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/topic/TopicConfigManager.java
+++ b/rocketmq-broker/src/main/java/com/alibaba/rocketmq/broker/topic/TopicConfigManager.java
@@ -30,7 +30,6 @@ import com.alibaba.rocketmq.common.sysflag.TopicSysFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -403,9 +402,8 @@ public class TopicConfigManager extends ConfigManager {
 
     @Override
     public String configFilePath() {
-//        return BrokerPathConfigHelper.getTopicConfigPath(this.brokerController.getMessageStoreConfig()
-//                .getStorePathRootDir());
-        return BrokerPathConfigHelper.getTopicConfigPath(System.getProperty("user.home") + File.separator + "store");
+        return BrokerPathConfigHelper.getTopicConfigPath(this.brokerController.getMessageStoreConfig()
+                .getStorePathRootDir());
     }
 
     @Override

--- a/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/plugin/MockMessageStore.java
+++ b/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/plugin/MockMessageStore.java
@@ -155,6 +155,11 @@ public class MockMessageStore implements MessageStore {
         return 0;
     }
 
+    @Override
+    public long getEarliestMessageTime() {
+        return 0;
+    }
+
 
     @Override
     public long getMessageStoreTimeStamp(String topic, int queueId, long offset) {
@@ -267,6 +272,11 @@ public class MockMessageStore implements MessageStore {
     @Override
     public boolean isOSPageCacheBusy() {
         return false;
+    }
+
+    @Override
+    public long lockTimeMills() {
+        return 0;
     }
 
 }


### PR DESCRIPTION
Topic and Subscription config files are incorrectly hard-coded to ${HOME}/store/config and configuration from broker.properties are ignored.

For now, the load method only allows ASCII characters, any non-ASCII character would cause the loading failure.

See MixAll#file2String(File) method.

```
public static final String file2String(final File file) {
    if (file.exists()) {
        char[] data = new char[(int) file.length()];
        boolean result = false;

        FileReader fileReader = null;
        try {
            fileReader = new FileReader(file);
            int len = fileReader.read(data);
            result = (len == data.length);
        } catch (IOException e) {
            // e.printStackTrace();
        } finally {
            if (fileReader != null) {
                try {
                    fileReader.close();
               } catch (IOException e) {
                   e.printStackTrace();
               }
           }
        }
```

 result = (len == data.length); would be false in case any non-ASCII characters are included.
