### PR TITLE
Fix bug

### DIFF
--- a/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
+++ b/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
@@ -246,7 +246,7 @@ public class StoreStatsService extends ServiceThread {
     private String getPutMessageDistributeTimeStringInfo() {
         final StringBuilder sb = new StringBuilder(512);
         Long total = 0L;
-        List<Long> copyListOfPutMessageDistributeTime = new ArrayList<Long>();
+        List<Long> copyListOfPutMessageDistributeTime = new ArrayList<Long>(this.putMessageDistributeTime.length);
         for (AtomicLong i : this.putMessageDistributeTime) {
             Long item = i.get();
             copyListOfPutMessageDistributeTime.add(item);

--- a/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
+++ b/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
@@ -22,9 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;

--- a/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
+++ b/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
@@ -199,7 +199,7 @@ public class StoreStatsService extends ServiceThread {
         sb.append("\tputMessageEntireTimeMax: " + this.putMessageEntireTimeMax + "\r\n");
         sb.append("\tputMessageTimesTotal: " + totalTimes + "\r\n");
         sb.append("\tputMessageSizeTotal: " + this.getPutMessageSizeTotal() + "\r\n");
-        sb.append("\tputMessageDistributeTime: " + this.getPutMessageDistributeTimeStringInfo(totalTimes)
+        sb.append("\tputMessageDistributeTime: " + this.getPutMessageDistributeTimeStringInfo()
                 + "\r\n");
         sb.append("\tputMessageAverageSize: " + (this.getPutMessageSizeTotal() / totalTimes.doubleValue())
                 + "\r\n");
@@ -245,16 +245,19 @@ public class StoreStatsService extends ServiceThread {
         return rs;
     }
 
-    private String getPutMessageDistributeTimeStringInfo(Long total) {
+    private String getPutMessageDistributeTimeStringInfo() {
         final StringBuilder sb = new StringBuilder(512);
-
+        Long total = 0L;
+        for (AtomicLong i : this.putMessageDistributeTime) {
+            total += i.get();
+        }
+        double doubleValueTotal = (total == 0 ? 1 : total);
         for (AtomicLong i : this.putMessageDistributeTime) {
             long value = i.get();
-            double ratio = value / total.doubleValue();
+            double ratio = value / doubleValueTotal;
             sb.append("\r\n\t\t");
             sb.append(value + "(" + (ratio * 100) + "%)");
         }
-
         return sb.toString();
     }
 
@@ -456,7 +459,7 @@ public class StoreStatsService extends ServiceThread {
         result.put("putMessageTimesTotal", String.valueOf(totalTimes));
         result.put("putMessageSizeTotal", String.valueOf(this.getPutMessageSizeTotal()));
         result.put("putMessageDistributeTime",
-                String.valueOf(this.getPutMessageDistributeTimeStringInfo(totalTimes)));
+                String.valueOf(this.getPutMessageDistributeTimeStringInfo()));
         result.put("putMessageAverageSize",
                 String.valueOf((this.getPutMessageSizeTotal() / totalTimes.doubleValue())));
         result.put("dispatchMaxBuffer", String.valueOf(this.dispatchMaxBuffer));

--- a/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
+++ b/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/StoreStatsService.java
@@ -248,12 +248,14 @@ public class StoreStatsService extends ServiceThread {
     private String getPutMessageDistributeTimeStringInfo() {
         final StringBuilder sb = new StringBuilder(512);
         Long total = 0L;
+        List<Long> copyListOfPutMessageDistributeTime = new ArrayList<Long>();
         for (AtomicLong i : this.putMessageDistributeTime) {
-            total += i.get();
+            Long item = i.get();
+            copyListOfPutMessageDistributeTime.add(item);
+            total += item;
         }
         double doubleValueTotal = (total == 0 ? 1 : total);
-        for (AtomicLong i : this.putMessageDistributeTime) {
-            long value = i.get();
+        for (Long value : copyListOfPutMessageDistributeTime) {
             double ratio = value / doubleValueTotal;
             sb.append("\r\n\t\t");
             sb.append(value + "(" + (ratio * 100) + "%)");

--- a/rocketmq-tools/src/main/java/com/alibaba/rocketmq/tools/command/topic/UpdateTopicPermSubCommand.java
+++ b/rocketmq-tools/src/main/java/com/alibaba/rocketmq/tools/command/topic/UpdateTopicPermSubCommand.java
@@ -60,7 +60,7 @@ public class UpdateTopicPermSubCommand implements SubCommand {
         opt.setRequired(true);
         options.addOption(opt);
 
-        opt = new Option("p", "perm", true, "set topic's permission(2|4|6), intro[2:R; 4:W; 6:RW]");
+        opt = new Option("p", "perm", true, "set topic's permission(2|4|6), intro[2:W; 4:R; 6:RW]");
         opt.setRequired(true);
         options.addOption(opt);
 


### PR DESCRIPTION
1.   UpdateTopicPermSubCommand  perm option:   R and W is wrong
//        @see com.alibaba.rocketmq.common.constant.PermName
//        public static final int PERM_READ = 0x1 << 2; 4 read
//        public static final int PERM_WRITE = 0x1 << 1; 2 write
//        opt = new Option("p", "perm", true, "set topic's permission(2|4|6), intro[2:R; 4:W; 6:RW]");

2. when we use mqAdmin fetchBrokerRuntimeStats ,the result of the putMessageDistributeTime is wrong .
putMessageDistributeTime will be changed by initPutMessageDistributeTime per PrintTPSInterval time,but putMessageTopicTimesTotal not,so we can't use putMessageTopicTimesTotal to calculate totalTimes,  each putMessageDistributeTime item should divide sum of putMessageDistributeTime to calculate the percentage.
@see  com.alibaba.rocketmq.store.StoreStatsService  printTps